### PR TITLE
Adicionando suporte para múltiplos tipos na filtragem de imóveis

### DIFF
--- a/src/main/java/model/entity/ImovelSeletor.java
+++ b/src/main/java/model/entity/ImovelSeletor.java
@@ -1,8 +1,11 @@
 package model.entity;
 
-public class ImovelSeletor extends BaseSeletor{
+import java.util.List;
+import java.util.ArrayList;
+
+public class ImovelSeletor extends BaseSeletor {
     private String nome;
-    private int tipo; // Alterar para arraylist de inteiros, contendo os ids de tipos de imovel
+    private List<Integer> tipos; // Lista de inteiros para os tipos de imóvel
     private int capacidadePessoas;
     private int qtdQuarto;
     private int qtdCama;
@@ -12,23 +15,24 @@ public class ImovelSeletor extends BaseSeletor{
     private int idAnfitriao;
 
     public ImovelSeletor() {
+        this.tipos = new ArrayList<>(); // Inicializar a lista de tipos
     }
 
-    public ImovelSeletor(String nome, int tipo, int capacidadePessoas, int qtdQuarto, int qtdCama, int qtdBanheiro,
-			boolean isOcupado, int idEndereco, int idAnfitriao) {
-		super();
-		this.nome = nome;
-		this.tipo = tipo;
-		this.capacidadePessoas = capacidadePessoas;
-		this.qtdQuarto = qtdQuarto;
-		this.qtdCama = qtdCama;
-		this.qtdBanheiro = qtdBanheiro;
-		this.isOcupado = isOcupado;
-		this.idEndereco = idEndereco;
-		this.idAnfitriao = idAnfitriao;
-	}
+    public ImovelSeletor(String nome, List<Integer> tipos, int capacidadePessoas, int qtdQuarto, int qtdCama, int qtdBanheiro,
+                         boolean isOcupado, int idEndereco, int idAnfitriao) {
+        super();
+        this.nome = nome;
+        this.tipos = tipos;
+        this.capacidadePessoas = capacidadePessoas;
+        this.qtdQuarto = qtdQuarto;
+        this.qtdCama = qtdCama;
+        this.qtdBanheiro = qtdBanheiro;
+        this.isOcupado = isOcupado;
+        this.idEndereco = idEndereco;
+        this.idAnfitriao = idAnfitriao;
+    }
 
-	public String getNome() {
+    public String getNome() {
         return nome;
     }
 
@@ -36,12 +40,12 @@ public class ImovelSeletor extends BaseSeletor{
         this.nome = nome;
     }
 
-    public int getTipo() {
-        return tipo;
+    public List<Integer> getTipos() {
+        return tipos;
     }
 
-    public void setTipo(int tipo) {
-        this.tipo = tipo;
+    public void setTipos(List<Integer> tipos) {
+        this.tipos = tipos;
     }
 
     public int getCapacidadePessoas() {
@@ -91,18 +95,18 @@ public class ImovelSeletor extends BaseSeletor{
     public void setIdEndereco(int idEndereco) {
         this.idEndereco = idEndereco;
     }
-    
+
     public int getIdAnfitriao() {
-		return idAnfitriao;
-	}
+        return idAnfitriao;
+    }
 
-	public void setIdAnfitriao(int idAnfitriao) {
-		this.idAnfitriao = idAnfitriao;
-	}
+    public void setIdAnfitriao(int idAnfitriao) {
+        this.idAnfitriao = idAnfitriao;
+    }
 
-	public boolean temFiltro(){
+    public boolean temFiltro() {
         return (this.getNome() != null && this.getNome().trim().length() > 0)
-                || (this.getTipo() > 0)
+                || (this.getTipos() != null && !this.getTipos().isEmpty())
                 || (this.getCapacidadePessoas() > 0)
                 || (this.getQtdQuarto() > 0)
                 || (this.getQtdCama() > 0)

--- a/src/main/java/model/repository/ImovelRepository.java
+++ b/src/main/java/model/repository/ImovelRepository.java
@@ -6,6 +6,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.List;
 
 import model.entity.Anfitriao;
 import model.entity.Endereco;
@@ -295,71 +296,88 @@ public class  ImovelRepository implements BaseRepository<Imovel>{
         return i;
     }
 
-    public String preencherFiltros(ImovelSeletor seletor, String query){
-        query += " WHERE i.id_anfitriao = " + seletor.getIdAnfitriao() + " ";
-        boolean primeiro = false;
+    public String preencherFiltros(ImovelSeletor seletor, String query) {
+        query += " WHERE ";
+        boolean primeiro = true;
 
-        if(seletor.getNome() != null){
-            if(!primeiro){
+        if (seletor.getNome() != null && !seletor.getNome().trim().isEmpty()) {
+            if (!primeiro) {
                 query += " AND ";
             }
             query += " UPPER(i.nome) LIKE UPPER('%" + seletor.getNome() + "%') ";
             primeiro = false;
         }
-        if(seletor.getTipo() > 0){
-            if(!primeiro){
+
+        List<Integer> tipos = seletor.getTipos();
+
+        if (tipos != null && !tipos.isEmpty()) {
+            if (!primeiro) {
                 query += " AND ";
             }
-            query += " i.tipo =" + seletor.getTipo(); // Trocar para o operador IN
+            query += " i.tipo IN (";
+
+            for (int i = 0; i < tipos.size(); i++) {
+                query += tipos.get(i);
+                if (i < tipos.size() - 1) {
+                    query += ", ";
+                }
+            }
+            query += ")";
             primeiro = false;
         }
-        if(seletor.getCapacidadePessoas() > 0){
-            if(!primeiro){
+
+        if (seletor.getCapacidadePessoas() > 0) {
+            if (!primeiro) {
                 query += " AND ";
             }
-            if(seletor.getCapacidadePessoas() >= 7) {
-            	query += " i.capacidadePessoas >= 7";
+            if (seletor.getCapacidadePessoas() >= 7) {
+                query += " i.capacidadePessoas >= 7";
             } else {
-            	query += " i.capacidadePessoas = " + seletor.getCapacidadePessoas();
+                query += " i.capacidadePessoas = " + seletor.getCapacidadePessoas();
             }
             primeiro = false;
         }
-        if(seletor.getQtdQuarto() > 0){
-            if(!primeiro){
+
+        if (seletor.getQtdQuarto() > 0) {
+            if (!primeiro) {
                 query += " AND ";
             }
             query += " i.qtdQuarto = " + seletor.getQtdQuarto();
             primeiro = false;
         }
-        if(seletor.getQtdCama() > 0){
-            if(!primeiro){
+
+        if (seletor.getQtdCama() > 0) {
+            if (!primeiro) {
                 query += " AND ";
             }
             query += " i.qtdCama = " + seletor.getQtdCama();
             primeiro = false;
         }
-        if(seletor.getQtdBanheiro() > 0){
-            if(!primeiro){
+
+        if (seletor.getQtdBanheiro() > 0) {
+            if (!primeiro) {
                 query += " AND ";
             }
             query += " i.qtdBanheiro = " + seletor.getQtdBanheiro();
             primeiro = false;
         }
-        if(seletor.getIsOcupado()){
-            if(!primeiro){
+
+        if (seletor.getIsOcupado()) {
+            if (!primeiro) {
                 query += " AND ";
             }
             query += " i.ocupado = " + seletor.getIsOcupado();
             primeiro = false;
         }
 
-        if(seletor.getIdEndereco() > 0){
-            if(!primeiro){
+        if (seletor.getIdEndereco() > 0) {
+            if (!primeiro) {
                 query += " AND ";
             }
             query += " i.id_endereco = " + seletor.getIdEndereco();
             primeiro = false;
         }
+
         return query;
     }
 }


### PR DESCRIPTION
Aprimorada a funcionalidade de filtragem de imóveis para suportar a seleção de múltiplos tipos simultaneamente. Agora, ao selecionar tipos específicos através do seletor, a consulta SQL é gerada dinamicamente para incluir todos os tipos selecionados na cláusula IN. Isso permite uma filtragem mais flexível e precisa dos resultados de imóveis no sistema.